### PR TITLE
Feature/sync if missing user

### DIFF
--- a/cas-client-integration-atlassian/pom.xml
+++ b/cas-client-integration-atlassian/pom.xml
@@ -80,53 +80,17 @@
         </dependency>
 
         <dependency>
-            <artifactId>atlassian-user</artifactId>
-            <groupId>com.atlassian.user</groupId>
-            <version>5.4.14</version>
+            <groupId>com.atlassian.crowd</groupId>
+            <artifactId>crowd-api</artifactId>
+            <version>2.10.4</version>
             <scope>provided</scope>
-            <type>jar</type>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>opensymphony</groupId>
-                    <artifactId>oscore</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>opensymphony</groupId>
-                    <artifactId>propertyset</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.transaction</groupId>
-                    <artifactId>jta</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>ofbcore</groupId>
-                    <artifactId>ofbcore-jira-entity</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>ofbcore</groupId>
-                    <artifactId>ofbcore-jira-share</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>dom4j</groupId>
-                    <artifactId>dom4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>com.atlassian.crowd</groupId>
+            <artifactId>crowd-core</artifactId>
+            <version>2.10.4</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <artifactId>atlassian-osuser</artifactId>
             <groupId>com.atlassian.osuser</groupId>
@@ -1461,6 +1425,10 @@
             <name>Atlassian 3rd Party Repository</name>
             <url>https://maven.atlassian.com/3rdparty/</url>
         </repository>
-
+        <repository>
+            <id>packages-atlassian</id>
+            <name>packages atlassian</name>
+            <url>https://packages.atlassian.com/maven-external/</url>
+        </repository>
     </repositories>
 </project>

--- a/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/ConfluenceCasAuthenticator.java
+++ b/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/ConfluenceCasAuthenticator.java
@@ -19,6 +19,11 @@
 package org.jasig.cas.client.integration.atlassian;
 
 import com.atlassian.confluence.user.ConfluenceAuthenticator;
+import com.atlassian.crowd.embedded.api.Directory;
+import com.atlassian.crowd.exception.DirectoryNotFoundException;
+import com.atlassian.crowd.exception.OperationFailedException;
+import com.atlassian.crowd.manager.directory.DirectoryManager;
+import com.atlassian.sal.api.component.ComponentLocator;
 import com.atlassian.seraph.auth.AuthenticatorException;
 import org.jasig.cas.client.util.AbstractCasFilter;
 import org.jasig.cas.client.validation.Assertion;
@@ -29,6 +34,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.security.Principal;
+import java.sql.Date;
 
 /**
  * Extension of ConfluenceAuthenticator to allow people to configure Confluence to authenticate
@@ -65,6 +71,13 @@ public final class ConfluenceCasAuthenticator extends ConfluenceAuthenticator {
 
             // user doesn't exist
             if (user == null) {
+                try {
+                    // The user wasn't found in confluence but is authenticated with cas.
+                    // Maybe the user was created after the last directory synchronization.
+                    synchronizeUsers();
+                } catch (OperationFailedException | DirectoryNotFoundException e) {
+                    e.printStackTrace();
+                }
                 LOGGER.error("Could not determine principal for [{}]", assertion.getPrincipal().getName());
                 getElevatedSecurityGuard().onFailedLoginAttempt(request, username);
                 return null;
@@ -79,6 +92,22 @@ public final class ConfluenceCasAuthenticator extends ConfluenceAuthenticator {
         }
 
         return super.getUser(request, response);
+    }
+
+    static synchronized void synchronizeUsers() throws OperationFailedException, DirectoryNotFoundException {
+        DirectoryManager directoryManager = ComponentLocator.getComponent(DirectoryManager.class);
+        for (Directory directory : directoryManager.findAllDirectories()) {
+            if (directoryManager.isSynchronisable(directory.getId())
+                    && !directoryManager.isSynchronising(directory.getId())) {
+                Date threshold = new Date(System.currentTimeMillis() - 30 * 1000);
+                if (directory.getUpdatedDate().before(threshold)) {
+                    LOGGER.debug("Synchronizing directory {}", directory.getName());
+                    directoryManager.synchroniseCache(directory.getId(), directoryManager.getSynchronisationMode(directory.getId()), false);
+                } else {
+                    LOGGER.debug("Directory {} was synchronized in the last 30 seconds", directory.getName());
+                }
+            }
+        }
     }
 
     public boolean logout(final HttpServletRequest request, final HttpServletResponse response)

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
 
     <modules>
         <module>cas-client-core</module>
-        <!-- <module>cas-client-integration-atlassian</module> -->
+        <module>cas-client-integration-atlassian</module>
         <module>cas-client-integration-jboss</module>
         <module>cas-client-support-distributed-ehcache</module>
         <module>cas-client-support-distributed-memcached</module>


### PR DESCRIPTION
This PR changes the behaviour of the confluence cas plugin:
If the authenticated user can not be found in confluence, a synchronization of the user directories will be executed.
To prevent unintended performance issues, the synchronization will not happen if multiple such cases appear in a small timespan (30 seconds).