### PR TITLE
add encoding-filter for confluence >= 8.0

### DIFF
--- a/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/Confluence80EncodingFilter.java
+++ b/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/atlassian/Confluence80EncodingFilter.java
@@ -1,0 +1,43 @@
+package org.jasig.cas.client.integration.atlassian;
+
+import org.apache.commons.lang.StringUtils;
+import org.jasig.cas.client.configuration.ConfigurationKeys;
+import org.jasig.cas.client.util.AbstractConfigurationFilter;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * Confluence80EncodingFilter sets the character-encoding of the request to the configured encoding (default: "UTF-8").
+ * This filter needs to be added before the other CAS-Filters because they will access request-parameters.
+ * Accessing request-parameters for post-requests without the proper encoding will also affect all subsequent filters (e.g. Confluence)
+ * because the request-parameters are cached once they have been read.
+ */
+public class Confluence80EncodingFilter extends AbstractConfigurationFilter {
+
+    private final String UTF8 = java.nio.charset.StandardCharsets.UTF_8.name();
+
+    private String encoding = UTF8;
+
+    @Override
+    public void init(final FilterConfig filterConfig) throws ServletException {
+        super.init(filterConfig);
+        this.encoding = getString(ConfigurationKeys.ENCODING);
+        if (StringUtils.isEmpty(this.encoding)) {
+            this.encoding = UTF8;
+        }
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        final HttpServletRequest request = (HttpServletRequest) servletRequest;
+        request.setCharacterEncoding(this.encoding);
+        filterChain.doFilter(request, servletResponse);
+    }
+
+    @Override
+    public void destroy() {
+        super.destroy();
+    }
+}

--- a/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/webapp/Confluence80CasWebApplicationInitializer.java
+++ b/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/webapp/Confluence80CasWebApplicationInitializer.java
@@ -43,6 +43,7 @@ public class Confluence80CasWebApplicationInitializer implements WebApplicationI
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
         logger.info("Initializing CAS SSO filters");
+        // apply the encoding filter first to avoid it not being applied at all due to caching. See {@link Confluence80EncodingFilter}
         initEncodingFilter(servletContext);
         initSingleSignOutFilter(servletContext);
         initAuthenticationFilter(servletContext);

--- a/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/webapp/Confluence80CasWebApplicationInitializer.java
+++ b/cas-client-integration-atlassian/src/main/java/org/jasig/cas/client/integration/webapp/Confluence80CasWebApplicationInitializer.java
@@ -10,6 +10,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
 import org.jasig.cas.client.authentication.AuthenticationFilter;
+import org.jasig.cas.client.integration.atlassian.Confluence80EncodingFilter;
 import org.jasig.cas.client.session.SingleSignOutFilter;
 import org.jasig.cas.client.validation.Cas20ProxyReceivingTicketValidationFilter;
 import org.springframework.core.Ordered;
@@ -42,10 +43,25 @@ public class Confluence80CasWebApplicationInitializer implements WebApplicationI
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
         logger.info("Initializing CAS SSO filters");
+        initEncodingFilter(servletContext);
         initSingleSignOutFilter(servletContext);
         initAuthenticationFilter(servletContext);
         initValidationFilter(servletContext);
         logger.info("End of initializing CAS SSO filters");
+    }
+
+    private void initEncodingFilter(ServletContext servletContext) {
+        FilterRegistration casEncodingFilterRegistration = servletContext.getFilterRegistration("CasEncodingFilter");
+        if (casEncodingFilterRegistration == null) {
+            casEncodingFilterRegistration = servletContext.addFilter("CasEncodingFilter", Confluence80EncodingFilter.class);
+        }
+        logger.info("Registering CAS encoding filter");
+
+        casEncodingFilterRegistration.addMappingForUrlPatterns(
+                EnumSet.allOf(DispatcherType.class),
+                false,
+                "/*");
+        logInitParams(casEncodingFilterRegistration);
     }
 
     private void initSingleSignOutFilter(ServletContext servletContext) {


### PR DESCRIPTION
Confluence80EncodingFilter sets the character-encoding of the request to the configured encoding (default: "UTF-8"). 
This filter needs to be added before the other CAS-Filters because they will access request-parameters. 
Accessing request-parameters for post-requests without the proper encoding will also affect all subsequent filters (e.g. Confluence) because the request-parameters are cached once they have been read.